### PR TITLE
Add 2x2 Grid Layout to Split View with Adjustable Dividers and Smart Transitions

### DIFF
--- a/pages/split/heroicons.js
+++ b/pages/split/heroicons.js
@@ -12,6 +12,12 @@ export const heroicons = {
     rotation: 90,
   },
 
+  grid: {
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
+  <path fill-rule="evenodd" d="M3 6a3 3 0 0 1 3-3h2.25a3 3 0 0 1 3 3v2.25a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6Zm9.75 0a3 3 0 0 1 3-3H18a3 3 0 0 1 3 3v2.25a3 3 0 0 1-3 3h-2.25a3 3 0 0 1-3-3V6ZM3 15.75a3 3 0 0 1 3-3h2.25a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3v-2.25Zm9.75 0a3 3 0 0 1 3-3H18a3 3 0 0 1 3 3V18a3 3 0 0 1-3 3h-2.25a3 3 0 0 1-3-3v-2.25Z" clip-rule="evenodd" />
+</svg>`,
+  },
+
   reload: {
     svg: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-4">
   <path fill-rule="evenodd" d="M4.755 10.059a7.5 7.5 0 0 1 12.548-3.364l1.903 1.903h-3.183a.75.75 0 1 0 0 1.5h4.992a.75.75 0 0 0 .75-.75V4.356a.75.75 0 0 0-1.5 0v3.18l-1.9-1.9A9 9 0 0 0 3.306 9.67a.75.75 0 1 0 1.45.388Zm15.408 3.352a.75.75 0 0 0-.919.53 7.5 7.5 0 0 1-12.548 3.364l-1.902-1.903h3.183a.75.75 0 0 0 0-1.5H2.984a.75.75 0 0 0-.75.75v4.992a.75.75 0 0 0 1.5 0v-3.18l1.9 1.9a9 9 0 0 0 15.059-4.035.75.75 0 0 0-.53-.918Z" clip-rule="evenodd" />

--- a/pages/split/insert.js
+++ b/pages/split/insert.js
@@ -6,6 +6,8 @@ import {
   attachIframeTitleListener,
   updateDocumentTitleFromIframes,
 } from './title.js';
+import { setLayoutToGrid } from './layout.js';
+import { updateUrlWithState } from './url.js';
 
 /**
  * Attach a hover-visible plus button to a divider that opens a tab picker.
@@ -279,23 +281,31 @@ export const insertAtDivider = (divider, url) => {
   addDividerDragFunctionality(newDivider);
   attachDividerPlus(newDivider);
 
-  // Rebalance sizes equally across all wrappers as ratios and recalc CSS sizes
+  // Rebalance sizes or switch to grid if reaching 4 wrappers
   const allWrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
     iframeContainer.querySelectorAll('.iframe-wrapper')
   );
-  const newRatio = 100 / allWrappers.length;
-  allWrappers.forEach((w) => {
-    /** @type {HTMLElement} */ (w).dataset.ratio = String(newRatio);
-    applyWrapperPrimarySize(w, newRatio, isVerticalLayout, iframeContainer);
-  });
+  if (allWrappers.length === 4) {
+    setLayoutToGrid();
+    updateDividerPlusVisibility();
+    updateDocumentTitleFromIframes();
+    updateUrlWithState();
+    return iframe;
+  } else {
+    const newRatio = 100 / allWrappers.length;
+    allWrappers.forEach((w) => {
+      /** @type {HTMLElement} */ (w).dataset.ratio = String(newRatio);
+      applyWrapperPrimarySize(w, newRatio, isVerticalLayout, iframeContainer);
+    });
 
-  // Recreate menus and normalize order/url
-  rebuildInterface();
-  updateDividerPlusVisibility();
-  // Ensure final calc sizes consider the new divider count
-  recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
-  updateDocumentTitleFromIframes();
-  return iframe;
+    // Recreate menus and normalize order/url
+    rebuildInterface();
+    updateDividerPlusVisibility();
+    // Ensure final calc sizes consider the new divider count
+    recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
+    updateDocumentTitleFromIframes();
+    return iframe;
+  }
 };
 
 /**
@@ -392,21 +402,29 @@ export const insertAtEdge = (position, url) => {
     divider.insertAdjacentElement('afterend', newWrapper);
   }
 
-  // Rebalance sizes equally across all wrappers
+  // Rebalance sizes or switch to grid if reaching 4 wrappers
   const allWrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
     iframeContainer.querySelectorAll('.iframe-wrapper')
   );
-  const newRatio = 100 / allWrappers.length;
-  allWrappers.forEach((w) => {
-    /** @type {HTMLElement} */ (w).dataset.ratio = String(newRatio);
-    applyWrapperPrimarySize(w, newRatio, isVerticalLayout, iframeContainer);
-  });
+  if (allWrappers.length === 4) {
+    setLayoutToGrid();
+    updateDividerPlusVisibility();
+    updateDocumentTitleFromIframes();
+    updateUrlWithState();
+    return iframe;
+  } else {
+    const newRatio = 100 / allWrappers.length;
+    allWrappers.forEach((w) => {
+      /** @type {HTMLElement} */ (w).dataset.ratio = String(newRatio);
+      applyWrapperPrimarySize(w, newRatio, isVerticalLayout, iframeContainer);
+    });
 
-  rebuildInterface();
-  updateDividerPlusVisibility();
-  recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
-  updateDocumentTitleFromIframes();
-  return iframe;
+    rebuildInterface();
+    updateDividerPlusVisibility();
+    recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
+    updateDocumentTitleFromIframes();
+    return iframe;
+  }
 };
 
 /**

--- a/pages/split/layout.js
+++ b/pages/split/layout.js
@@ -3,15 +3,45 @@ import { heroicons } from './heroicons.js';
 import { updateCssOrder } from './ordering.js';
 import { updateUrlWithState } from './url.js';
 import { recalcAllWrapperSizes } from './size.js';
+import {
+  addDividerDragFunctionality,
+  addGridDividerDragFunctionality,
+} from './drag.js';
+import { attachDividerPlus } from './insert.js';
+
+import { rebuildInterface } from './rebuild.js';
 
 export const applyLayout = () => {
   const iframeContainer = appState.getContainer();
-  const isVerticalLayout = appState.getIsVerticalLayout();
+  const mode = appState.getLayoutMode();
+  const isVerticalLayout = mode === 'vertical';
+  const isGridLayout = mode === 'grid';
 
-  if (isVerticalLayout) {
+  if (isGridLayout) {
+    // Grid: 2x2 matrix with adjustable splits
+    iframeContainer.className =
+      'grid grid-cols-2 grid-rows-2 h-screen w-screen';
+    const col = appState.getGridColumnPercent();
+    const row = appState.getGridRowPercent();
+    iframeContainer.style.display = 'grid';
+    iframeContainer.style.gridTemplateColumns = `${col}% ${100 - col}%`;
+    iframeContainer.style.gridTemplateRows = `${row}% ${100 - row}%`;
+    // Remove any stale linear dividers or previous grid dividers before adding
+    Array.from(
+      iframeContainer.querySelectorAll(
+        '.iframe-divider, [data-sb-grid-divider]',
+      ),
+    ).forEach((el) => el.remove());
+  } else if (isVerticalLayout) {
     iframeContainer.className = 'flex flex-col h-screen w-screen';
+    iframeContainer.style.display = '';
+    iframeContainer.style.gridTemplateColumns = '';
+    iframeContainer.style.gridTemplateRows = '';
   } else {
     iframeContainer.className = 'flex flex-row h-screen w-screen';
+    iframeContainer.style.display = '';
+    iframeContainer.style.gridTemplateColumns = '';
+    iframeContainer.style.gridTemplateRows = '';
   }
 
   const iframes = /** @type {NodeListOf<HTMLIFrameElement>} */ (
@@ -20,41 +50,115 @@ export const applyLayout = () => {
   const dividers = /** @type {NodeListOf<HTMLDivElement>} */ (
     document.querySelectorAll('.iframe-divider')
   );
-  const wrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
-    document.querySelectorAll('.iframe-wrapper')
+  const wrappers = /** @type {HTMLDivElement[]} */ (
+    Array.from(document.querySelectorAll('.iframe-wrapper'))
   );
 
   iframes.forEach((iframe) => {
-    if (isVerticalLayout) {
+    // Reset inline sizing first to avoid stale styles across mode changes
+    iframe.style.width = '';
+    iframe.style.height = '';
+    if (isGridLayout) {
       iframe.className =
-        'resizable-iframe w-full border border-gray-300 box-border rounded-lg pointer-events-auto flex-shrink-0 flex-grow-0';
+        'resizable-iframe w-full h-full border border-gray-300 box-border rounded-lg pointer-events-auto';
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+    } else if (isVerticalLayout) {
+      iframe.className =
+        'resizable-iframe w-full h-full border border-gray-300 box-border rounded-lg pointer-events-auto flex-shrink-0 flex-grow-0';
       iframe.style.width = '100%';
       iframe.style.height = '100%';
     } else {
       iframe.className =
-        'resizable-iframe h-full border border-gray-300 box-border rounded-lg pointer-events-auto flex-shrink-0 flex-grow-0';
+        'resizable-iframe h-full w-full border border-gray-300 box-border rounded-lg pointer-events-auto flex-shrink-0 flex-grow-0';
       iframe.style.width = '100%';
       iframe.style.height = '100%';
     }
   });
 
-  // Recalculate wrapper sizes using stored ratios and divider count
-  recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
+  if (isGridLayout) {
+    // Remove all linear dividers in grid layout
+    dividers.forEach((d) => d.remove());
 
-  // Enforce fixed 4px thickness (Tailwind h-1/w-1) for dividers
-  dividers.forEach((divider) => {
-    if (isVerticalLayout) {
-      divider.className =
-        'iframe-divider group relative bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 h-1 w-full cursor-row-resize min-h-1 flex-shrink-0 flex-grow-0';
-      /** @type {HTMLElement} */ (divider).style.height = '4px';
-      /** @type {HTMLElement} */ (divider).style.width = '';
-    } else {
-      divider.className =
-        'iframe-divider group relative bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 w-1 h-full cursor-col-resize min-w-1 flex-shrink-0 flex-grow-0';
-      /** @type {HTMLElement} */ (divider).style.width = '4px';
-      /** @type {HTMLElement} */ (divider).style.height = '';
+    // Clear wrapper inline sizes and reorder DOM by logical order TL,TR,BL,BR
+    const sorted = wrappers
+      .map((w, domIndex) => ({
+        el: w,
+        orderValue: Number.parseInt(
+          /** @type {HTMLElement} */ (w).style.order || `${domIndex * 2}`,
+          10,
+        ),
+      }))
+      .sort((a, b) => a.orderValue - b.orderValue)
+      .map((x) => x.el);
+
+    sorted.forEach((w, idx) => {
+      /** @type {HTMLElement} */ (w).style.width = '';
+      /** @type {HTMLElement} */ (w).style.height = '';
+      // Ensure wrappers are direct children in the right DOM order for CSS Grid
+      iframeContainer.appendChild(w);
+      // Normalize wrapper order indices to preserve movement semantics
+      /** @type {HTMLElement} */ (w).style.order = String(idx * 2);
+    });
+
+    // Add grid dividers: one vertical and one horizontal
+    // vertical divider overlay
+    const vDivider = document.createElement('div');
+    vDivider.dataset.sbGridDivider = 'vertical';
+    vDivider.className =
+      'absolute top-0 bottom-0 w-1 cursor-col-resize bg-base-300/70 hover:bg-blue-400 z-20';
+    vDivider.style.position = 'absolute';
+    vDivider.style.left = `calc(${appState.getGridColumnPercent()}% - 2px)`;
+    vDivider.style.top = '0';
+    vDivider.style.bottom = '0';
+    iframeContainer.appendChild(vDivider);
+    addGridDividerDragFunctionality(vDivider, 'vertical');
+
+    const hDivider = document.createElement('div');
+    hDivider.dataset.sbGridDivider = 'horizontal';
+    hDivider.className =
+      'absolute left-0 right-0 h-1 cursor-row-resize bg-base-300/70 hover:bg-blue-400 z-20';
+    hDivider.style.position = 'absolute';
+    hDivider.style.top = `calc(${appState.getGridRowPercent()}% - 2px)`;
+    hDivider.style.left = '0';
+    hDivider.style.right = '0';
+    iframeContainer.appendChild(hDivider);
+    addGridDividerDragFunctionality(hDivider, 'horizontal');
+  } else {
+    // Non-grid: Recalculate wrapper sizes using stored ratios and divider count
+    // Remove any grid-specific dividers if present
+    Array.from(
+      iframeContainer.querySelectorAll('[data-sb-grid-divider]'),
+    ).forEach((el) => el.remove());
+
+    // Ensure wrappers get equal primary size if coming from grid (no ratios)
+    const wrappersNoRatio = wrappers.filter(
+      (w) => !(/** @type {HTMLElement} */ (w).dataset.ratio),
+    );
+    if (wrappersNoRatio.length > 0) {
+      const equal = wrappers.length > 0 ? 100 / wrappers.length : 100;
+      wrappers.forEach((w) => {
+        /** @type {HTMLElement} */ (w).dataset.ratio = String(equal);
+      });
     }
-  });
+
+    recalcAllWrapperSizes(iframeContainer, isVerticalLayout);
+
+    // Enforce fixed 4px thickness (Tailwind h-1/w-1) for dividers
+    dividers.forEach((divider) => {
+      if (isVerticalLayout) {
+        divider.className =
+          'iframe-divider group relative bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 h-1 w-full cursor-row-resize min-h-1 flex-shrink-0 flex-grow-0';
+        /** @type {HTMLElement} */ (divider).style.height = '4px';
+        /** @type {HTMLElement} */ (divider).style.width = '';
+      } else {
+        divider.className =
+          'iframe-divider group relative bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 w-1 h-full cursor-col-resize min-w-1 flex-shrink-0 flex-grow-0';
+        /** @type {HTMLElement} */ (divider).style.width = '4px';
+        /** @type {HTMLElement} */ (divider).style.height = '';
+      }
+    });
+  }
 
   updateCssOrder();
 };
@@ -66,9 +170,63 @@ export const toggleLayout = () => {
   updateUrlWithState();
 };
 
+export const setLayoutToGrid = () => {
+  appState.setLayoutMode('grid');
+  // In grid, equalize size implicitly via grid; clear ratios for clarity
+  const iframeContainer = appState.getContainer();
+  const wrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
+    iframeContainer.querySelectorAll('.iframe-wrapper')
+  );
+  wrappers.forEach((w) => {
+    /** @type {HTMLElement} */ (w).dataset.ratio = '';
+  });
+  applyLayout();
+  rebuildInterface();
+  updateButtonLabels();
+  updateUrlWithState();
+};
+
+export const setLayoutToHorizontal = () => {
+  appState.setLayoutMode('horizontal');
+  const iframeContainer = appState.getContainer();
+  // Rebuild linear dividers and reset equal widths
+  ensureLinearDividers();
+  const wrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
+    iframeContainer.querySelectorAll('.iframe-wrapper')
+  );
+  const equal = wrappers.length > 0 ? 100 / wrappers.length : 100;
+  wrappers.forEach((w) => {
+    /** @type {HTMLElement} */ (w).dataset.ratio = String(equal);
+  });
+  applyLayout();
+  rebuildInterface();
+  updateButtonLabels();
+  updateUrlWithState();
+};
+
+export const setLayoutToVertical = () => {
+  appState.setLayoutMode('vertical');
+  const iframeContainer = appState.getContainer();
+  // Rebuild linear dividers and reset equal heights
+  ensureLinearDividers();
+  const wrappers = /** @type {NodeListOf<HTMLDivElement>} */ (
+    iframeContainer.querySelectorAll('.iframe-wrapper')
+  );
+  const equal = wrappers.length > 0 ? 100 / wrappers.length : 100;
+  wrappers.forEach((w) => {
+    /** @type {HTMLElement} */ (w).dataset.ratio = String(equal);
+  });
+  applyLayout();
+  rebuildInterface();
+  updateButtonLabels();
+  updateUrlWithState();
+};
+
 export const updateButtonLabels = () => {
   const iframeContainer = appState.getContainer();
-  const isVerticalLayout = appState.getIsVerticalLayout();
+  const mode = appState.getLayoutMode();
+  const isVerticalLayout = mode === 'vertical';
+  const isGridLayout = mode === 'grid';
   const wrappers = Array.from(iframeContainer.children).filter((child) =>
     child.classList.contains('iframe-wrapper'),
   );
@@ -78,6 +236,12 @@ export const updateButtonLabels = () => {
     if (menu) {
       const layoutBtn = /** @type {HTMLButtonElement|null} */ (
         menu.querySelector('button[data-role="layout"]')
+      );
+      const toHorizontalBtn = /** @type {HTMLButtonElement|null} */ (
+        menu.querySelector('button[data-role="to-horizontal"]')
+      );
+      const toVerticalBtn = /** @type {HTMLButtonElement|null} */ (
+        menu.querySelector('button[data-role="to-vertical"]')
       );
       const moveLeftBtn = /** @type {HTMLButtonElement|null} */ (
         menu.querySelector('button[data-role="move-left"]')
@@ -102,6 +266,31 @@ export const updateButtonLabels = () => {
           : 'Vertical layout';
       }
 
+      if (toHorizontalBtn) {
+        toHorizontalBtn.innerHTML = heroicons.rows.svg;
+        const svg = /** @type {SVGElement|null} */ (
+          toHorizontalBtn.querySelector('svg')
+        );
+        if (svg) {
+          const baseRotation = (heroicons.rows && heroicons.rows.rotation) ?? 0;
+          svg.style.transform = `rotate(${baseRotation}deg)`;
+        }
+        toHorizontalBtn.title = 'Horizontal layout';
+      }
+
+      if (toVerticalBtn) {
+        toVerticalBtn.innerHTML = heroicons.columns.svg;
+        const svg = /** @type {SVGElement|null} */ (
+          toVerticalBtn.querySelector('svg')
+        );
+        if (svg) {
+          const baseRotation =
+            (heroicons.columns && heroicons.columns.rotation) ?? 0;
+          svg.style.transform = `rotate(${baseRotation}deg)`;
+        }
+        toVerticalBtn.title = 'Vertical layout';
+      }
+
       if (moveLeftBtn) {
         const svg = /** @type {SVGElement|null} */ (
           moveLeftBtn.querySelector('svg')
@@ -109,10 +298,14 @@ export const updateButtonLabels = () => {
         if (svg) {
           const baseRotation =
             (heroicons.moveLeft && heroicons.moveLeft.rotation) ?? 0;
-          const extraRotation = isVerticalLayout ? -90 : 0;
+          const extraRotation = isGridLayout ? 0 : isVerticalLayout ? -90 : 0;
           svg.style.transform = `rotate(${baseRotation + extraRotation}deg)`;
         }
-        moveLeftBtn.title = isVerticalLayout ? 'Move up' : 'Move left';
+        moveLeftBtn.title = isGridLayout
+          ? 'Move left'
+          : isVerticalLayout
+          ? 'Move up'
+          : 'Move left';
       }
 
       if (moveRightBtn) {
@@ -122,11 +315,66 @@ export const updateButtonLabels = () => {
         if (svg) {
           const baseRotation =
             (heroicons.moveRight && heroicons.moveRight.rotation) ?? 0;
-          const extraRotation = isVerticalLayout ? 90 : 0;
+          const extraRotation = isGridLayout ? 0 : isVerticalLayout ? 90 : 0;
           svg.style.transform = `rotate(${baseRotation + extraRotation}deg)`;
         }
-        moveRightBtn.title = isVerticalLayout ? 'Move down' : 'Move right';
+        moveRightBtn.title = isGridLayout
+          ? 'Move right'
+          : isVerticalLayout
+          ? 'Move down'
+          : 'Move right';
       }
     }
   });
+};
+
+// Ensure there is a divider between each adjacent pair of wrappers in linear layouts
+export const ensureLinearDividers = () => {
+  const iframeContainer = appState.getContainer();
+  const isVerticalLayout = appState.getIsVerticalLayout();
+  // Remove all existing dividers and add fresh ones between wrappers
+  const existing = /** @type {NodeListOf<HTMLDivElement>} */ (
+    iframeContainer.querySelectorAll('.iframe-divider')
+  );
+  existing.forEach((d) => d.remove());
+
+  const wrappers = /** @type {HTMLDivElement[]} */ (
+    Array.from(iframeContainer.querySelectorAll('.iframe-wrapper'))
+  );
+
+  const sorted = wrappers
+    .map((w, domIndex) => ({
+      el: w,
+      orderValue: Number.parseInt(
+        /** @type {HTMLElement} */ (w).style.order || `${domIndex * 2}`,
+        10,
+      ),
+    }))
+    .sort((a, b) => a.orderValue - b.orderValue)
+    .map((x) => x.el);
+
+  sorted.forEach((w, index) => {
+    /** @type {HTMLElement} */ (w).style.order = String(index * 2);
+  });
+
+  for (let i = 0; i < sorted.length - 1; i++) {
+    const left = sorted[i];
+    const divider = document.createElement('div');
+    divider.className = 'iframe-divider group relative';
+    if (isVerticalLayout) {
+      divider.className +=
+        ' bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 h-1 w-full cursor-row-resize min-h-1 relative flex-shrink-0 flex-grow-0';
+      /** @type {HTMLElement} */ (divider).style.height = '4px';
+      /** @type {HTMLElement} */ (divider).style.width = '';
+    } else {
+      divider.className +=
+        ' bg-base-300 dark:bg-gray-600 hover:bg-blue-400 transition-colors delay-300 m-0 p-0 w-1 h-full cursor-col-resize min-w-1 relative flex-shrink-0 flex-grow-0';
+      /** @type {HTMLElement} */ (divider).style.width = '4px';
+      /** @type {HTMLElement} */ (divider).style.height = '';
+    }
+    /** @type {HTMLElement} */ (divider).style.order = String(i * 2 + 1);
+    left.insertAdjacentElement('afterend', divider);
+    addDividerDragFunctionality(divider);
+    attachDividerPlus(divider);
+  }
 };

--- a/pages/split/menu.js
+++ b/pages/split/menu.js
@@ -1,11 +1,18 @@
 import { appState } from './state.js';
 import { heroicons } from './heroicons.js';
-import { toggleLayout } from './layout.js';
+import {
+  toggleLayout,
+  setLayoutToGrid,
+  setLayoutToHorizontal,
+  setLayoutToVertical,
+} from './layout.js';
 import { moveIframe } from './move.js';
 import { removeIframe } from './remove.js';
 
 export const createIframeMenu = (_iframeWrapper, index, totalCount) => {
-  const isVerticalLayout = appState.getIsVerticalLayout();
+  const mode = appState.getLayoutMode();
+  const isVerticalLayout = mode === 'vertical';
+  const isGridLayout = mode === 'grid';
 
   const menu = document.createElement('div');
   menu.className =
@@ -25,15 +32,51 @@ export const createIframeMenu = (_iframeWrapper, index, totalCount) => {
     return svg || container;
   };
 
-  const layoutBtn = document.createElement('button');
-  layoutBtn.className =
-    'btn btn-xs btn-ghost hover:btn-primary min-w-6 h-6 text-xs leading-none';
-  layoutBtn.dataset.role = 'layout';
-  // Show the action icon (what it will switch to)
-  layoutBtn.appendChild(createHeroicon(isVerticalLayout ? 'columns' : 'rows'));
-  layoutBtn.title = isVerticalLayout ? 'Horizontal layout' : 'Vertical layout';
-  layoutBtn.addEventListener('click', toggleLayout);
-  menu.appendChild(layoutBtn);
+  if (isGridLayout) {
+    // In grid, show explicit Horizontal and Vertical buttons
+    const toHorizontalBtn = document.createElement('button');
+    toHorizontalBtn.className =
+      'btn btn-xs btn-ghost hover:btn-primary min-w-6 h-6 text-xs leading-none';
+    toHorizontalBtn.dataset.role = 'to-horizontal';
+    toHorizontalBtn.appendChild(createHeroicon('columns'));
+    toHorizontalBtn.title = 'Horizontal layout';
+    toHorizontalBtn.addEventListener('click', setLayoutToHorizontal);
+    menu.appendChild(toHorizontalBtn);
+
+    const toVerticalBtn = document.createElement('button');
+    toVerticalBtn.className =
+      'btn btn-xs btn-ghost hover:btn-primary min-w-6 h-6 text-xs leading-none';
+    toVerticalBtn.dataset.role = 'to-vertical';
+    toVerticalBtn.appendChild(createHeroicon('rows'));
+    toVerticalBtn.title = 'Vertical layout';
+    toVerticalBtn.addEventListener('click', setLayoutToVertical);
+    menu.appendChild(toVerticalBtn);
+  } else {
+    // In linear layouts, show a Grid switcher plus the existing toggle
+    if (totalCount === 4) {
+      const gridBtn = document.createElement('button');
+      gridBtn.className =
+        'btn btn-xs btn-ghost hover:btn-primary min-w-6 h-6 text-xs leading-none';
+      gridBtn.dataset.role = 'grid';
+      gridBtn.appendChild(createHeroicon('grid'));
+      gridBtn.title = 'Grid layout';
+      gridBtn.addEventListener('click', setLayoutToGrid);
+      menu.appendChild(gridBtn);
+    }
+
+    const layoutBtn = document.createElement('button');
+    layoutBtn.className =
+      'btn btn-xs btn-ghost hover:btn-primary min-w-6 h-6 text-xs leading-none';
+    layoutBtn.dataset.role = 'layout';
+    layoutBtn.appendChild(
+      createHeroicon(isVerticalLayout ? 'columns' : 'rows'),
+    );
+    layoutBtn.title = isVerticalLayout
+      ? 'Horizontal layout'
+      : 'Vertical layout';
+    layoutBtn.addEventListener('click', toggleLayout);
+    menu.appendChild(layoutBtn);
+  }
 
   const reloadBtn = document.createElement('button');
   reloadBtn.className =
@@ -97,7 +140,7 @@ export const createIframeMenu = (_iframeWrapper, index, totalCount) => {
     const moveLeftIcon = /** @type {SVGElement} */ (createHeroicon('moveLeft'));
     const baseRotation =
       (heroicons.moveLeft && heroicons.moveLeft.rotation) ?? 0;
-    const extraRotation = isVerticalLayout ? -90 : 0;
+    const extraRotation = isVerticalLayout ? 90 : 0;
     moveLeftIcon.style.transform = `rotate(${baseRotation + extraRotation}deg)`;
     moveLeftBtn.appendChild(moveLeftIcon);
     moveLeftBtn.title = isVerticalLayout ? 'Move up' : 'Move left';

--- a/pages/split/remove.js
+++ b/pages/split/remove.js
@@ -3,6 +3,7 @@ import { rebuildInterface } from './rebuild.js';
 import { updateDividerPlusVisibility } from './insert.js';
 import { applyWrapperPrimarySize, recalcAllWrapperSizes } from './size.js';
 import { updateDocumentTitleFromIframes } from './title.js';
+import { setLayoutToHorizontal } from './layout.js';
 
 const closeTabIfSingleRemaining = () => {
   const remainingWrappers = document.querySelectorAll('.iframe-wrapper');
@@ -98,6 +99,18 @@ export const removeIframe = (index) => {
     }
 
     const remainingWrappers = document.querySelectorAll('.iframe-wrapper');
+
+    // If we were in grid and now have 3 wrappers, switch to horizontal layout
+    if (
+      typeof appState.getLayoutMode === 'function' &&
+      appState.getLayoutMode() === 'grid' &&
+      remainingWrappers.length === 3
+    ) {
+      setLayoutToHorizontal();
+      updateDividerPlusVisibility();
+      return;
+    }
+
     const newRatio = 100 / remainingWrappers.length;
     remainingWrappers.forEach((wrapper) => {
       /** @type {HTMLElement} */ (wrapper).dataset.ratio = String(newRatio);

--- a/pages/split/state.js
+++ b/pages/split/state.js
@@ -2,7 +2,11 @@
 
 export const appState = {
   iframeContainer: /** @type {HTMLDivElement | null} */ (null),
-  isVerticalLayout: false,
+  // layoutMode can be 'horizontal' | 'vertical' | 'grid'
+  layoutMode: /** @type {'horizontal'|'vertical'|'grid'} */ ('horizontal'),
+  // Grid split percentages (for 2x2): left column width and top row height
+  gridColumnPercent: 50,
+  gridRowPercent: 50,
   setContainer(el) {
     this.iframeContainer = el;
   },
@@ -11,13 +15,43 @@ export const appState = {
       throw new Error('iframeContainer not initialized');
     return this.iframeContainer;
   },
+  // Back-compat APIs with prior boolean vertical state
   setVerticalLayout(isVertical) {
-    this.isVerticalLayout = Boolean(isVertical);
+    this.layoutMode = isVertical ? 'vertical' : 'horizontal';
   },
   getIsVerticalLayout() {
-    return this.isVerticalLayout;
+    return this.layoutMode === 'vertical';
   },
   toggleVerticalLayout() {
-    this.isVerticalLayout = !this.isVerticalLayout;
+    // Only toggles between horizontal and vertical
+    if (this.layoutMode === 'vertical') this.layoutMode = 'horizontal';
+    else this.layoutMode = 'vertical';
+  },
+  // New layout mode helpers
+  setLayoutMode(mode) {
+    if (mode === 'horizontal' || mode === 'vertical' || mode === 'grid') {
+      this.layoutMode = mode;
+    }
+  },
+  getLayoutMode() {
+    return this.layoutMode;
+  },
+  getIsGridLayout() {
+    return this.layoutMode === 'grid';
+  },
+  // Grid split setters/getters
+  setGridColumnPercent(p) {
+    const clamped = Math.max(5, Math.min(95, Number(p)));
+    this.gridColumnPercent = clamped;
+  },
+  getGridColumnPercent() {
+    return this.gridColumnPercent;
+  },
+  setGridRowPercent(p) {
+    const clamped = Math.max(5, Math.min(95, Number(p)));
+    this.gridRowPercent = clamped;
+  },
+  getGridRowPercent() {
+    return this.gridRowPercent;
   },
 };

--- a/pages/split/url.js
+++ b/pages/split/url.js
@@ -2,8 +2,7 @@ import { appState } from './state.js';
 import { getWrapperRatioPercent } from './size.js';
 
 export const updateUrlWithState = () => {
-  const iframeContainer = appState.getContainer();
-  const isVerticalLayout = appState.getIsVerticalLayout();
+  const mode = appState.getLayoutMode();
 
   const wrappers = /** @type {HTMLDivElement[]} */ (
     Array.from(document.querySelectorAll('.iframe-wrapper'))
@@ -42,9 +41,6 @@ export const updateUrlWithState = () => {
     currentUrls.map((u) => encodeURIComponent(u)).join(','),
   );
   newUrl.searchParams.set('ratios', currentRatios.join(','));
-  newUrl.searchParams.set(
-    'layout',
-    isVerticalLayout ? 'vertical' : 'horizontal',
-  );
+  newUrl.searchParams.set('layout', mode);
   window.history.replaceState({}, '', newUrl.toString());
 };


### PR DESCRIPTION
### Description
This PR introduces a new 2x2 grid layout to the split page with adjustable horizontal and vertical dividers, improves layout transitions, and enhances UX around adding/removing iframes.

### What’s new
- Grid layout mode with CSS Grid (2x2) and two adjustable dividers:
  - One vertical and one horizontal divider to resize columns/rows.
  - Live resizing via drag; persisted during the session.
- Menu updates:
  - In linear layouts (when there are exactly 4 iframes): show a Grid button.
  - In grid layout: show Horizontal and Vertical buttons.
  - Move buttons keep existing order logic; titles/rotations adapt per mode.
- Smart defaults and transitions:
  - Default to Grid when creating a split page with 4 tabs.
  - Auto-switch to Grid when adding a new iframe brings total to 4.
  - Auto-switch to Horizontal when removing from Grid reduces total to 3.
  - Clean transitions:
    - Grid → Horizontal: full height, equal width.
    - Grid → Vertical: full width, equal height.
    - Linear → Grid: equal size tiles.
- URL state:
  - `layout` now supports `horizontal` | `vertical` | `grid` (backward compatible with old boolean vertical param).
- State model extended:
  - Tracks `layoutMode` and grid row/column percentages for the 2x2 split.

### Files of interest
- `pages/split/state.js`: layout mode + grid split state.
- `pages/split/layout.js`: apply modes; build/remove dividers; clean transitions.
- `pages/split/menu.js`: menu entries for mode switching.
- `pages/split/drag.js`: drag handlers for grid dividers.
- `pages/split/insert.js`: auto-switch to Grid at 4 iframes.
- `pages/split/remove.js`: auto-switch to Horizontal when dropping to 3 from Grid.
- `pages/split/url.js`: sync layout as a string.
- `pages/split/entry.js`: default-to-grid when 4 URLs, grid-safe initial sizing.

### Testing
- Open with 4 URLs: should default to grid, equal sizes; both dividers present and draggable.
- Add iframes until reaching 4: should auto-switch to grid.
- Remove one iframe from grid (4 → 3): should auto-switch to horizontal with equal widths and full height.
- Switch between modes via menu:
  - Grid → Horizontal: equal widths, full height.
  - Grid → Vertical: equal heights, full width.
  - Horizontal/Vertical → Grid: equal tiles; grid dividers appear.
- Verify move-left/right still respects order TL, TR, BL, BR in grid.
- Confirm URL `layout` reflects the active mode.
- Confirm initial sizes are correct in all modes (no leftover inline styles).

### Backward compatibility
- Preserves old `vertical` param handling; maps to new `layoutMode`.
- No breaking API changes expected.